### PR TITLE
Simply Customizable RedHat initscript

### DIFF
--- a/redhat-init-mingalevme
+++ b/redhat-init-mingalevme
@@ -14,6 +14,7 @@
 #
 # description:  supervisor is a process control utility.  It has a web based
 #               xmlrpc interface as well as a few other nifty features.
+#               Script was originally written by Jason Koppe <jkoppe@indeed.com>.
 #
 
 # source function library


### PR DESCRIPTION
Script **redhat-init-mingalevme** was based on **redhat-init-jkoppe** and **redhat-sysconfig-jkoppe**, but was rewritten to single file without **sysconfig**, also the run options and bins was moved to variables.
