### PR TITLE
Removing .sock file when stopping supervisord

### DIFF
--- a/ubuntu
+++ b/ubuntu
@@ -26,7 +26,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/local/bin/supervisord
 NAME=supervisord
 DESC=supervisor
-DAEMON_OPTS="-c /etc/supervisord/supervisord.conf"
+DAEMON_OPTS=""
 
 test -x $DAEMON || exit 0
 


### PR DESCRIPTION
Remove the supervisor.sock file when we stop supervisord. This allows the script to start supervisord.
Without this, when restarting supervisord, a message appears saying that the port is already in use.
