### PR TITLE
Debian 6.0

### DIFF
--- a/debian-isnok
+++ b/debian-isnok
@@ -28,9 +28,9 @@ DAEMON=/usr/local/bin/supervisord  # Python package index (pypi) version (3.0b1)
 NAME=supervisord
 DESC="supervisor - Run a set of applications as daemons"
 
-CONFIGFILE=/etc/supervisord.conf      # the supervisord config file
-SUPERVISORCTL=/usr/bin/supervisorctl  # used for reload command(s)
-#SUPERVISORCTL=/usr/local/bin/supervisorctl  # again: official deb version
+CONFIGFILE=/etc/supervisord.conf            # the supervisord config file
+SUPERVISORCTL=/usr/local/bin/supervisorctl  # used for reload command(s)
+#SUPERVISORCTL=/usr/bin/supervisorctl       # again: official deb version
 
 if test ! -x $DAEMON; then
     echo "ERROR: Not executable: $DAEMON"
@@ -42,7 +42,7 @@ PIDFILE=/var/run/$NAME.pid
 DODTIME=5                   # Time to wait for the server to die, in seconds
                             # If this value is set too low you might not
                             # let some servers to die gracefully and
-                            # 'restart' will not work
+                            # 'restart' will not work.
 
 # fix some args for certain commands
 DAEMON_ARGS="-c $CONFIGFILE"

--- a/debian-isnok
+++ b/debian-isnok
@@ -22,16 +22,16 @@
 
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-#DAEMON=/usr/bin/supervisord       # Debian package version (presently 3.0a8-1)
-DAEMON=/usr/local/bin/supervisord  # Python package index (pypi) version (3.0b1)
+DAEMON=/usr/bin/supervisord         # Debian package version (presently 3.0a8-1)
+#DAEMON=/usr/local/bin/supervisord  # Python package index (pypi) version (3.0b1)
 NAME=supervisord
 DESC="a python process supervisor"
 
 CONFIGFILE=/etc/supervisord.conf            # the supervisord config file
-SUPERVISORCTL=/usr/local/bin/supervisorctl  # used for reload command(s)
-#SUPERVISORCTL=/usr/bin/supervisorctl       # again: official deb version
+SUPERVISORCTL=/usr/bin/supervisorctl        # used for reload command(s)
+#SUPERVISORCTL=/usr/local/bin/supervisorctl # for use with pypi version
 
-if [ ! -x $DAEMON ]; then
+if command -v $DAEMON >/dev/null 2>&1; then
     echo "ERROR: Not executable: $DAEMON"
     exit 0
 fi
@@ -97,7 +97,7 @@ running () {
 
 normal_start () {
       start-stop-daemon $STARTSTOP_ARGS --start \
-          --exec "$DAEMON" -- "$DAEMON_ARGS" $DAEMON_OPTS
+          --exec "$DAEMON" -- $DAEMON_ARGS $DAEMON_OPTS
       if [ ! -f "$PIDFILE" ]; then
           sleep 1  # grace time to create PIDFILE
       fi

--- a/debian-isnok
+++ b/debian-isnok
@@ -30,6 +30,7 @@ DESC="supervisor - Run a set of applications as daemons"
 
 CONFIGFILE=/etc/supervisord.conf      # the supervisord config file
 SUPERVISORCTL=/usr/bin/supervisorctl  # used for reload command(s)
+#SUPERVISORCTL=/usr/local/bin/supervisorctl  # again: official deb version
 
 if test ! -x $DAEMON; then
     echo "ERROR: Not executable: $DAEMON"

--- a/debian-isnok
+++ b/debian-isnok
@@ -45,8 +45,8 @@ DODTIME=5                   # Time to wait for the server to die, in seconds
                             # 'restart' will not work.
 
 # fix some args for certain commands
-DAEMON_ARGS="-c $CONFIGFILE"
-CTL_ARGS="-c $CONFIGFILE"
+DAEMON_ARGS="-c$CONFIGFILE"
+CTL_ARGS="-c$CONFIGFILE"
 STARTSTOP_ARGS="--quiet --pidfile $PIDFILE --exec $DAEMON"
 
 # Include supervisor defaults if available
@@ -90,9 +90,9 @@ running () {
     # Now, obtain the pid and check it's /proc cmdline:
     pid="$(cat $PIDFILE)"
     if running_pid "$pid" "$DAEMON"; then
-        return 1
-    else
         return 0
+    else
+        return 1
     fi
 }
 
@@ -105,7 +105,8 @@ normal_start () {
 }
 
 normal_stop () {
-    start-stop-daemon $STARTSTOP_ARGS --stop --oknodo
+    #start-stop-daemon $STARTSTOP_ARGS --stop --oknodo
+    "$SUPERVISORCTL" $CTL_ARGS shutdown
 }
 
 force_stop () {
@@ -203,7 +204,7 @@ case "$1" in
             echo "running:"
             ctl_status
         else
-            echo " not running."
+            echo "not running."
             exit 1
         fi
         ;;

--- a/debian-isnok
+++ b/debian-isnok
@@ -1,14 +1,13 @@
 #! /bin/sh
 #
-# skeleton      example file to build /etc/init.d/ scripts.
-#               This file should be used to construct scripts for /etc/init.d.
+# supervisor    built from skeleton /etc/init.d/ script.
 #
-#               Written by Miquel van Smoorenburg <miquels@cistron.nl>.
+#               skeleton by Miquel van Smoorenburg <miquels@cistron.nl>.
 #               Modified for Debian by Ian Murdock <imurdock@gnu.ai.mit.edu>.
 #               Further changes by Javier Fernandez-Sanguino <jfs@debian.org>.
 #               More changes by Konstantin Martini <isnok@tuxcode.org>.
 #
-# Version:      @(#)skeleton  1.9  26-Feb-2001  miquels@cistron.nl
+# Version:      @(#)supervisor  0.8  25-Jun-2013  isnok@tuxcode.org
 #
 ### BEGIN INIT INFO
 # Provides:          supervisor
@@ -16,7 +15,7 @@
 # Required-Stop:     $remote_fs $network $named
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Start/stop supervisor
+# Short-Description: Start/stop supervisord
 # Description:       Start/stop supervisor daemon and its configured
 #                    subprocesses.
 ### END INIT INFO
@@ -26,13 +25,13 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 #DAEMON=/usr/bin/supervisord       # Debian package version (presently 3.0a8-1)
 DAEMON=/usr/local/bin/supervisord  # Python package index (pypi) version (3.0b1)
 NAME=supervisord
-DESC="supervisor - Run a set of applications as daemons"
+DESC="a python process supervisor"
 
 CONFIGFILE=/etc/supervisord.conf            # the supervisord config file
 SUPERVISORCTL=/usr/local/bin/supervisorctl  # used for reload command(s)
 #SUPERVISORCTL=/usr/bin/supervisorctl       # again: official deb version
 
-if test ! -x $DAEMON; then
+if [ ! -x $DAEMON ]; then
     echo "ERROR: Not executable: $DAEMON"
     exit 0
 fi
@@ -145,7 +144,7 @@ ctl_status () {
 
 case "$1" in
     start)
-        echo -n "Starting $NAME: "
+        echo -n "Starting $DESC: "
         normal_start
         if running; then
             echo "$NAME."
@@ -154,7 +153,7 @@ case "$1" in
         fi
         ;;
     stop)
-        echo -n "Stopping $NAME: "
+        echo -n "Stopping $DESC: "
         if normal_stop; then
             echo "$NAME."
         else
@@ -162,11 +161,11 @@ case "$1" in
         fi
         ;;
     restart)
-        echo "Restart $DESC."
+        echo "Restarting $DESC..."
         "$0" stop && "$0" start
         ;;
     force-stop)
-        echo -n "Forcefully stopping $NAME: "
+        echo -n "Forcefully stopping $DESC: "
         force_stop
         if running; then
             echo "$NAME."
@@ -182,7 +181,7 @@ case "$1" in
         #    If the daemon responds to changes in its config file
         #    directly anyway, make this a do-nothing entry.
         #
-        echo "Reloading $NAME: "
+        echo "Reloading $DESC: "
         if ctl_reload; then
             echo "$NAME."
         else

--- a/debian-isnok
+++ b/debian-isnok
@@ -1,0 +1,216 @@
+#! /bin/sh
+#
+# skeleton      example file to build /etc/init.d/ scripts.
+#               This file should be used to construct scripts for /etc/init.d.
+#
+#               Written by Miquel van Smoorenburg <miquels@cistron.nl>.
+#               Modified for Debian by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+#               Further changes by Javier Fernandez-Sanguino <jfs@debian.org>.
+#               More changes by Konstantin Martini <isnok@tuxcode.org>.
+#
+# Version:      @(#)skeleton  1.9  26-Feb-2001  miquels@cistron.nl
+#
+### BEGIN INIT INFO
+# Provides:          supervisor
+# Required-Start:    $remote_fs $network $named
+# Required-Stop:     $remote_fs $network $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start/stop supervisor
+# Description:       Start/stop supervisor daemon and its configured
+#                    subprocesses.
+### END INIT INFO
+
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+#DAEMON=/usr/bin/supervisord       # Debian package version (presently 3.0a8-1)
+DAEMON=/usr/local/bin/supervisord  # Python package index (pypi) version (3.0b1)
+NAME=supervisord
+DESC="supervisor - Run a set of applications as daemons"
+
+CONFIGFILE=/etc/supervisord.conf      # the supervisord config file
+SUPERVISORCTL=/usr/bin/supervisorctl  # used for reload command(s)
+
+if test ! -x $DAEMON; then
+    echo "ERROR: Not executable: $DAEMON"
+    exit 0
+fi
+
+LOGDIR=/var/log/supervisor
+PIDFILE=/var/run/$NAME.pid
+DODTIME=5                   # Time to wait for the server to die, in seconds
+                            # If this value is set too low you might not
+                            # let some servers to die gracefully and
+                            # 'restart' will not work
+
+# fix some args for certain commands
+DAEMON_ARGS="-c $CONFIGFILE"
+CTL_ARGS="-c $CONFIGFILE"
+STARTSTOP_ARGS="--quiet --pidfile $PIDFILE --exec $DAEMON"
+
+# Include supervisor defaults if available
+if [ -r /etc/default/supervisor ]; then
+    . /etc/default/supervisor
+fi
+
+set -e
+
+dod_sleep () {
+    if [ -n "$DODTIME" ]; then
+        sleep "$DODTIME"s
+    fi
+}
+
+running_pid () {
+    # Check if a pid's cmdline contains a string (name).
+    # This should work for all users.
+    pid="$1"
+    name="$2"
+    if [ -z "$pid" ]; then
+        return 1  # no pid given
+    fi
+    if [ ! -d /proc/"$pid" ]; then
+        return 1  # no /proc/$pid directory
+    fi
+    if cat /proc/"$pid"/cmdline | tr "\000" "\n"| grep -q "$name"; then
+        return 0
+    else
+        return 1  # $pid does not match $name
+    fi
+}
+
+running () {
+    # Check if DAEMON is running by examining $PIDFILE.
+    # If this succeeds, it sets $pid (a side effect being used).
+
+    if [ ! -f "$PIDFILE" ]; then
+        return 1  # No pidfile, probably no daemon present.
+    fi
+    # Now, obtain the pid and check it's /proc cmdline:
+    pid="$(cat $PIDFILE)"
+    if running_pid "$pid" "$DAEMON"; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+normal_start () {
+      start-stop-daemon $STARTSTOP_ARGS --start \
+          --exec "$DAEMON" -- "$DAEMON_ARGS" "$DAEMON_OPTS"
+      if [ ! -f "$PIDFILE" ]; then
+          sleep 1  # grace time to create PIDFILE
+      fi
+}
+
+normal_stop () {
+    start-stop-daemon $STARTSTOP_ARGS --stop --oknodo
+}
+
+force_stop () {
+    # Forcefully stop a running DAEMON.
+    if running; then
+        kill -15 "$pid"
+        dod_sleep
+        # Check again, try harder if needed.
+        if running; then
+            kill -9 "$pid"
+            dod_sleep
+            if running; then
+                echo "Unable to kill running $NAME process (pid=$pid)!"
+                exit 1
+            fi
+        fi
+    fi
+    rm -f "$PIDFILE"
+    return 0
+}
+
+ctl_reload () {
+    # make supervisord reload it's config
+    if [ -x "$SUPERVISORCTL" ]; then
+        "$SUPERVISORCTL" $CTL_ARGS reload
+    else
+        return 1
+    fi
+}
+
+ctl_status () {
+    # show stati of supervised processes.
+    # do not mind if this fails.
+    "$SUPERVISORCTL" $CTL_ARGS status
+}
+
+case "$1" in
+    start)
+        echo -n "Starting $DESC: "
+        normal_start
+        if running; then
+            echo "$NAME."
+        else
+            echo "ERROR."
+        fi
+        ;;
+    stop)
+        echo -n "Stopping $DESC: "
+        if normal_stop; then
+            echo "$NAME."
+        else
+            echo "ERROR."
+        fi
+        ;;
+    restart)
+        echo "Restart $DESC."
+        "$0" stop && "$0" start
+        ;;
+    force-stop)
+        echo -n "Forcefully stopping $DESC: "
+        force_stop
+        if running; then
+            echo "$NAME."
+        else
+            echo "ERROR."
+        fi
+        ;;
+    reload|force-reload)
+        #
+        #    If the daemon can reload its config files on the fly
+        #    for example by sending it SIGHUP, do it here.
+        #
+        #    If the daemon responds to changes in its config file
+        #    directly anyway, make this a do-nothing entry.
+        #
+        echo "Reloading $DESC: "
+        if ctl_reload; then
+            echo "$NAME."
+        else
+            echo "ERROR."
+        fi
+        ;;
+    #force-reload)
+        #
+        #    If the "reload" option is implemented, move the "force-reload"
+        #    option to the "reload" entry above. If not, "force-reload" is
+        #    just the same as "restart" except that it does nothing if the
+        #    daemon isn't already running.
+        #    Check wether $DAEMON is running. If so, restart.
+        #echo "Not implemented."
+        #;;
+    status)
+        echo -n "$NAME is "
+        if running; then
+            echo "running:"
+            ctl_status
+        else
+            echo " not running."
+            exit 1
+        fi
+        ;;
+    *)
+        N=/etc/init.d/"$NAME"
+        echo "Usage: $N {start|stop|restart|reload|status|force-stop}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/debian-isnok
+++ b/debian-isnok
@@ -98,7 +98,7 @@ running () {
 
 normal_start () {
       start-stop-daemon $STARTSTOP_ARGS --start \
-          --exec "$DAEMON" -- "$DAEMON_ARGS" "$DAEMON_OPTS"
+          --exec "$DAEMON" -- "$DAEMON_ARGS" $DAEMON_OPTS
       if [ ! -f "$PIDFILE" ]; then
           sleep 1  # grace time to create PIDFILE
       fi
@@ -144,7 +144,7 @@ ctl_status () {
 
 case "$1" in
     start)
-        echo -n "Starting $DESC: "
+        echo -n "Starting $NAME: "
         normal_start
         if running; then
             echo "$NAME."
@@ -153,7 +153,7 @@ case "$1" in
         fi
         ;;
     stop)
-        echo -n "Stopping $DESC: "
+        echo -n "Stopping $NAME: "
         if normal_stop; then
             echo "$NAME."
         else
@@ -165,7 +165,7 @@ case "$1" in
         "$0" stop && "$0" start
         ;;
     force-stop)
-        echo -n "Forcefully stopping $DESC: "
+        echo -n "Forcefully stopping $NAME: "
         force_stop
         if running; then
             echo "$NAME."
@@ -181,7 +181,7 @@ case "$1" in
         #    If the daemon responds to changes in its config file
         #    directly anyway, make this a do-nothing entry.
         #
-        echo "Reloading $DESC: "
+        echo "Reloading $NAME: "
         if ctl_reload; then
             echo "$NAME."
         else

--- a/debian-norrgard
+++ b/debian-norrgard
@@ -1,4 +1,5 @@
 #! /bin/sh
+
 ### BEGIN INIT INFO
 # Provides:          supervisord
 # Required-Start:    $local_fs $remote_fs $networking
@@ -12,27 +13,42 @@
 # Author: Leonard Norrgard <leonard.norrgard@refactor.fi>
 # Version 1.0-alpha
 # Based on the /etc/init.d/skeleton script in Debian.
+#
+# Contributor: Konstantin Martini <https://github.com/isnok>
+# Version 1.0-beta
+# Upgraded from 1.0-alpha.
+#
+# Please note: This script is not yet very well tested.
+# The testing that actually was done was on supervisor 2.2b1 (alpha version of this script).
+#
+# Some more testing (without re-testing earlier versions) was done on
+# Debian 6.0.7 using supervisor 3.0b1 installed from pypi (not the
+# official debian package) in combination with python 2.6 and 2.7.
 
-# Please note: This script is not yet well tested. What little testing
-# that actually was done was only on supervisor 2.2b1.
 
 # Do NOT "set -e"
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="Run a set of applications as daemons."
-NAME=supervisord
-DAEMON=/usr/bin/$NAME   # Supervisord is installed in /usr/bin by default, but /usr/sbin would make more sense.
-SUPERVISORCTL=/usr/bin/supervisorctl
-PIDFILE=/var/run/$NAME.pid
-DAEMON_ARGS="--pidfile ${PIDFILE}"
-SCRIPTNAME=/etc/init.d/$NAME
 
-# Exit if the package is not installed
-[ -x "$DAEMON" ] || exit 0
+# Supervisord is installed in /usr/bin by default, but /usr/sbin would make more sense.
+NAME=supervisord
+DESC="Run a set of applications as daemons."
+DAEMON=/usr/bin/"$NAME"
+SUPERVISORCTL=/usr/bin/supervisorctl
+PIDFILE=/var/run/"$NAME.pid"
+DAEMON_ARGS="--pidfile $PIDFILE"
+SCRIPTNAME=/etc/init.d/"$NAME"
+
+# Check if $DAEMON is executable.
+if [ ! -x "$DAEMON" ]; then
+    exit 0
+fi
 
 # Read configuration variable file if it is present
-[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+if [ -r /etc/default/"$NAME" ]; then
+    . /etc/default/"$NAME"
+fi
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh

--- a/debian-supervised-isnok
+++ b/debian-supervised-isnok
@@ -24,9 +24,9 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 NAME=supervised                             # <--- hook your service here
 DESC="a supervised service"
 
-SUPERVISORCTL=/usr/local/bin/supervisorctl  # used to control supervisord
-#SUPERVISORCTL=/usr/bin/supervisorctl       # (official debian version)
-CONFIGFILE=/etc/supervisord.conf            # the supervisord config file
+SUPERVISORCTL=/usr/bin/supervisorctl        # from debian package
+#SUPERVISORCTL=/usr/local/bin/supervisorctl # if installed via pip
+CONFIGFILE=/etc/supervisor/supervisord.conf # the supervisord config file
 CTL_ARGS="-c$CONFIGFILE"
 
 if [ ! -x "$SUPERVISORCTL" ]; then

--- a/debian-supervised-isnok
+++ b/debian-supervised-isnok
@@ -29,7 +29,7 @@ SUPERVISORCTL=/usr/bin/supervisorctl        # from debian package
 CONFIGFILE=/etc/supervisor/supervisord.conf # the supervisord config file
 CTL_ARGS="-c$CONFIGFILE"
 
-if command -v "$SUPERVISORCTL" >/dev/null 2>&1; then
+if [ ! -x "$SUPERVISORCTL" ]; then
     echo "ERROR: Not executable: $SUPERVISORCTL"
     exit 0
 fi

--- a/debian-supervised-isnok
+++ b/debian-supervised-isnok
@@ -1,0 +1,135 @@
+#! /bin/sh
+#
+# supervised    built from supervisor /etc/init.d/ script.
+#
+#               skeleton by Miquel van Smoorenburg <miquels@cistron.nl>.
+#               Modified for Debian by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+#               Further changes by Javier Fernandez-Sanguino <jfs@debian.org>.
+#               More changes by Konstantin Martini <isnok@tuxcode.org>.
+#
+# Version:      @(#)supervised  0.8  25-Jun-2013  isnok@tuxcode.org
+#
+### BEGIN INIT INFO
+# Provides:          supervised
+# Required-Start:    $supervisor
+# Required-Stop:     $supervisor
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start/stop (python-)supervised service
+# Description:       Start/stop (python-)supervised service
+### END INIT INFO
+
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME=supervised                             # <--- hook your service here
+DESC="a supervised service"
+
+SUPERVISORCTL=/usr/local/bin/supervisorctl  # used to control supervisord
+#SUPERVISORCTL=/usr/bin/supervisorctl       # (official debian version)
+CONFIGFILE=/etc/supervisord.conf            # the supervisord config file
+CTL_ARGS="-c$CONFIGFILE"
+
+if [ ! -x "$SUPERVISORCTL" ]; then
+    echo "ERROR: Not executable: $SUPERVISORCTL"
+    exit 0
+fi
+
+# Include supervisor defaults if available
+#if [ -r /etc/default/supervisor ]; then
+#    . /etc/default/supervisor
+#fi
+
+set -e
+
+supctl () {
+    "$SUPERVISORCTL" $CTL_ARGS "$@"
+}
+
+running () {
+    # Check if NAME is running by examining status output.
+    supctl status "$NAME" | grep -q " RUNNING "
+}
+
+#force_stop () {
+#    # Forcefully stop a running DAEMON.
+#    if running; then
+#        kill -15 "$pid"
+#        dod_sleep
+#        # Check again, try harder if needed.
+#        if running; then
+#            kill -9 "$pid"
+#            dod_sleep
+#            if running; then
+#                echo "Unable to kill running $NAME process (pid=$pid)!"
+#                exit 1
+#            fi
+#        fi
+#    fi
+#    rm -f "$PIDFILE"
+#    return 0
+#}
+
+ctl_status () {
+    # show status of supervised process.
+    supctl status "$NAME"
+}
+
+normal_start () {
+    supctl start "$NAME"
+}
+
+normal_stop () {
+    supctl stop "$NAME"
+}
+
+
+case "$1" in
+    start)
+        echo -n "Starting $DESC: "
+        normal_start
+        if running; then
+            echo "$NAME."
+        else
+            echo "ERROR."
+        fi
+        ;;
+    stop)
+        echo -n "Stopping $DESC: "
+        if normal_stop; then
+            echo "$NAME."
+        else
+            echo "ERROR."
+        fi
+        ;;
+    restart)
+        echo "Restarting $DESC..."
+        "$0" stop && "$0" start
+        ;;
+#    force-stop)
+#        echo -n "Forcefully stopping $DESC: "
+#        force_stop
+#        if running; then
+#            echo "$NAME."
+#        else
+#            echo "ERROR."
+#        fi
+#        ;;
+    status)
+        echo -n "$NAME is "
+        if running; then
+            echo "running:"
+            ctl_status
+        else
+            echo "not running."
+            exit 1
+        fi
+        ;;
+    *)
+        N=/etc/init.d/"$NAME"
+        #echo "Usage: $N {start|stop|restart|status|force-stop}" >&2
+        echo "Usage: $N {start|stop|restart|status}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/debian-supervised-isnok
+++ b/debian-supervised-isnok
@@ -25,11 +25,11 @@ NAME=supervised                             # <--- hook your service here
 DESC="a supervised service"
 
 SUPERVISORCTL=/usr/bin/supervisorctl        # from debian package
-#SUPERVISORCTL=/usr/local/bin/supervisorctl # if installed via pip
+#SUPERVISORCTL=/usr/local/bin/supervisorctl # if installed via pip from pypi
 CONFIGFILE=/etc/supervisor/supervisord.conf # the supervisord config file
 CTL_ARGS="-c$CONFIGFILE"
 
-if [ ! -x "$SUPERVISORCTL" ]; then
+if command -v "$SUPERVISORCTL" >/dev/null 2>&1; then
     echo "ERROR: Not executable: $SUPERVISORCTL"
     exit 0
 fi
@@ -42,7 +42,7 @@ fi
 set -e
 
 supctl () {
-    "$SUPERVISORCTL" $CTL_ARGS "$@"
+    "$SUPERVISORCTL" $CTL_ARGS $DAEMON_OPTS "$@"
 }
 
 running () {


### PR DESCRIPTION
I did this some time ago. It contains three changes:

A) First I started to improve the existing debian script from norrgard. Until I realized, that it was created for a quite old debian version, and that it's not too hard to start off ...

B) A new script to start supervisord. This one bases on the official init.d skeleton (i think of debian 6.0).

C) I realized, that still I needed more init scripts (for the supervised processes), that's what the -supervised scipt is for. it's basically just a wrapper around supervisorctl to keep some things consistent from an admin point of view.