### PR TITLE
Checks if supervisord is up when status is called

### DIFF
--- a/redhat-init-mingalevme
+++ b/redhat-init-mingalevme
@@ -22,7 +22,7 @@
 
 set -a
 
-PREFIX=/opt/sentry
+PREFIX=/usr
 
 SUPERVISORD=$PREFIX/bin/supervisord
 SUPERVISORCTL=$PREFIX/bin/supervisorctl
@@ -30,7 +30,7 @@ SUPERVISORCTL=$PREFIX/bin/supervisorctl
 PIDFILE=/var/run/supervisord.pid
 LOCKFILE=/var/lock/subsys/supervisord
 
-OPTIONS="-c /opt/sentry/etc/supervisord.conf"
+OPTIONS="-c /etc/supervisord.conf"
 
 # unset this variable if you don't care to wait for child processes to shutdown before removing the $LOCKFILE-lock
 WAIT_FOR_SUBPROCESSES=yes
@@ -39,6 +39,31 @@ WAIT_FOR_SUBPROCESSES=yes
 ulimit -n 96000
 
 RETVAL=0
+
+
+running_pid()
+{
+    # Check if a given process pid's cmdline matches a given name
+    pid=$1
+    name=$2
+    [ -z "$pid" ] && return 1
+    [ ! -d /proc/$pid ] && return 1
+    (cat /proc/$pid/cmdline | tr "\000" "\n"|grep -q $name) || return 1
+    return 0
+}
+
+running()
+{
+# Check if the process is running looking at /proc
+# (works for all users)
+
+    # No pidfile, probably no daemon present
+    [ ! -f "$PIDFILE" ] && return 1
+    # Obtain the pid and check it against the binary name
+    pid=`cat $PIDFILE`
+    running_pid $pid $SUPERVISORD || return 1
+    return 0
+}
 
 start() {
         echo "Starting supervisord: "
@@ -112,7 +137,11 @@ case "$1" in
         ;;
     status)
         $SUPERVISORCTL status
-        RETVAL=$?
+        if running ; then
+            RETVAL=0
+        else
+            RETVAL=1
+        fi
         ;;
     *)
         echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart}"


### PR DESCRIPTION
Calling supervisorctl status will always return 0. Here I'm using the same method used in the ubuntu initscript to check if the process is really running.
