### PR TITLE
redhat-init-mingalevme - don't use nounset

### DIFF
--- a/redhat-init-mingalevme
+++ b/redhat-init-mingalevme
@@ -19,9 +19,6 @@
 #               Script was originally written by Jason Koppe <jkoppe@indeed.com>.
 #
 
-# Treat unset variables as error
-set -o nounset
-
 # source function library
 . /etc/rc.d/init.d/functions
 


### PR DESCRIPTION
This causes the script to fail because it purposely uses unset variables $1 and $total_sleep.

You can see the error when running the init script without parameters and when running stop.