### PR TITLE
add freebsd init

### DIFF
--- a/freebsd-init-ishworgurung
+++ b/freebsd-init-ishworgurung
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# $FreeBSD: branches/2018Q2/sysutils/py-supervisor/files/supervisord.in 340872 2014-01-24 00:14:07Z mat $
+#
+# PROVIDE: supervisord
+# REQUIRE: DAEMON
+# KEYWORD: shutdown
+#
+# Add the following line to /etc/rc.conf.local or /etc/rc.conf
+# to enable supervisord:
+#
+# supervisord_enable="bool"	Set to NO by default.
+#				Set it to YES to enable supervisord.
+# supervisord_config (patch):	Set to /usr/local/etc/supervisord.conf by default.
+# supervisord_user (username):	Set to root by default.
+#
+
+. /etc/rc.subr
+
+name="supervisord"
+rcvar=supervisord_enable
+
+load_rc_config $name
+
+: ${supervisord_enable="NO"}
+: ${supervisord_config="/usr/local/etc/supervisord.conf"}
+: ${supervisord_user="root"}
+
+command="/usr/local/bin/${name}"
+command_args="-u ${supervisord_user} -c ${supervisord_config}"
+command_interpreter="/usr/local/bin/python2.7"
+pidfile="/var/run/supervisor/${name}.pid"
+
+run_rc_command "$1"


### PR DESCRIPTION
Details

init: `/usr/local/etc/rc.d/supervisord`
pkg: `pkg install py27-supervisor-3.3.3,1`
os: `FreeBSD zorbit 11.1-RELEASE FreeBSD 11.1-RELEASE #0 r321309: Fri Jul 21 02:08:28 UTC 2017     root@releng2.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC  amd64`
system knob: `echo 'supervisord_enable="YES" ' >> /etc/rc.conf` (or /etc/rc.conf.local)