### PR TITLE
Fix error on comparing sleep and 'last' while stopping

### DIFF
--- a/redhat-init-jkoppe
+++ b/redhat-init-jkoppe
@@ -58,7 +58,7 @@ stop() {
                 echo "Supervisord exited as expected in under $total_sleep seconds"
                 break
             else
-                if [[ $sleep -eq "last" ]] ; then
+                if [[ $sleep = "last" ]] ; then
                     echo "Supervisord still working on shutting down. We've waited roughly 60 seconds, we'll let it do its thing from here"
                     return 1
                 else

--- a/redhat-init-mingalevme
+++ b/redhat-init-mingalevme
@@ -95,7 +95,7 @@ stop() {
                     echo "Supervisord exited as expected in under $total_sleep seconds"
                     break
                 else
-                    if [[ $sleep -eq "last" ]] ; then
+                    if [[ $sleep = "last" ]] ; then
                         echo "Supervisord still working on shutting down. We've waited roughly 60 seconds, we'll let it do its thing from here"
                         return 1
                     else


### PR DESCRIPTION
```
$ sudo /sbin/service supervisord restart
Stopping supervisord: Shut down
Waiting roughly 60 seconds for /var/run/supervisord.pid to be removed after child processes exit
/etc/init.d/supervisord: line 61: last: unbound variable
```
-eq is comparing both as number, so "last" is considered as avariable name and then try to expand the value of the variable "last".
Should be =

```
    # always remove the subsys.  we might have waited a while, but just remove it at this point.
    rm -f /var/lock/subsys/supervisord
```
So this logic is not reached and lock file is remaining as a result.
```
$ ls -lah /var/lock/subsys/supervisord
-rw-r--r-- 1 root root 0 Feb 14 13:21 /var/lock/subsys/supervisord
$ ps aux | grep supervisor
user   4546  0.0  0.0 103316   912 pts/0    S+   13:27   0:00 grep supervisor
$ sudo /sbin/service supervisord status
unix:///var/run/supervisor.sock no such file
supervisord dead but subsys locked
```

Here is my environment I tested
```
$ cat /etc/redhat-release 
CentOS release 6.10 (Final)
$ uname -r
2.6.32-754.6.3.el6.x86_64
$ bash --version
GNU bash, version 4.1.2(2)-release (x86_64-redhat-linux-gnu)
Copyright (C) 2009 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
$ /sbin/service --version
service ver. 0.91
$ supervisord -v
3.3.5
```