### PR TITLE
fix a bug cause daemon cannot correct find the running process.

### DIFF
--- a/redhat-init-equeffelec
+++ b/redhat-init-equeffelec
@@ -52,7 +52,7 @@ RETVAL=0
 
 start() {
     echo -n $"Starting $prog: "
-    daemon --pidfile=${pidfile} $supervisord $OPTIONS
+    daemon $supervisord $OPTIONS --pidfile=${pidfile}
     RETVAL=$?
     echo
     if [ $RETVAL -eq 0 ]; then


### PR DESCRIPTION
in the code
```
daemon --pidfile=${pidfile} $supervisord $OPTIONS
```
daemon use pidfile /var/run/supervisord.pid to check if supervisord is runing, but supervisord did not write its pid to the file, so daemon can not find the running instance.


then move the args to pass to supervisord, 
```
daemon $supervisord $OPTIONS --pidfile=${pidfile}
```
tell it to write pid to the pidfile, and daemon also check this file with no args as its default behavior, and can find the right runing instance.
