### PR TITLE
Create supervisord.service-Debian11

### DIFF
--- a/supervisord.service-Debian11
+++ b/supervisord.service-Debian11
@@ -1,0 +1,16 @@
+# supervisord service for systemd (Debian 11)
+# by DarkFlib (https://github.com/darkflib)
+[Unit]
+Description=Supervisor daemon
+
+[Service]
+Type=forking
+ExecStart=/usr/local/bin/supervisord $OPTIONS -c /etc/supervisord.conf
+ExecStop=/usr/local/bin/supervisorctl $OPTIONS shutdown
+ExecReload=/usr/local/bin/supervisorctl $OPTIONS reload
+KillMode=process
+Restart=on-failure
+RestartSec=30s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Needed to install supervisord on a debian 11 install which is systemd based. The RH/CentOS version was close, but the paths are wrong for debian. It may work on other systemd based distros - probably earlier debian versions and ubuntu, but this is untested.

Hopefully this will help others.